### PR TITLE
Handle volumenames with spaces...

### DIFF
--- a/lib/diskinfo.js
+++ b/lib/diskinfo.js
@@ -128,7 +128,7 @@ exports.getDrives = function(callback) {
 														used:		aTokens[2],
 														available:	aTokens[3],
 														capacity:	aTokens[4],
-														mounted:	aTokens.slice(aTokens.length+1).join(' ')
+														mounted:	aTokens.slice(5,aTokens.length+1).join(' ')
 													  };
 							
 						}

--- a/lib/diskinfo.js
+++ b/lib/diskinfo.js
@@ -128,7 +128,7 @@ exports.getDrives = function(callback) {
 														used:		aTokens[2],
 														available:	aTokens[3],
 														capacity:	aTokens[4],
-														mounted:	aTokens[5]
+														mounted:	aTokens.slice(aTokens.length+1).join(' ')
 													  };
 							
 						}


### PR DESCRIPTION
Extended your explicit array index call to handle all the remaining items in the array rather than just the 6th... which is gonna happen with that regexp, and macos...  Gracefully does the exact same thing when there is only 6 items in the array.

-Dx